### PR TITLE
fixed turn, added __init__ and requirements.py

### DIFF
--- a/pi/helmsman/__init__.py
+++ b/pi/helmsman/__init__.py
@@ -1,0 +1,1 @@
+from helmsman.helmsman import Helmsman

--- a/pi/helmsman/helmsman.py
+++ b/pi/helmsman/helmsman.py
@@ -1,4 +1,5 @@
-import rudder_controller
+from helmsman import rudder_controller
+
 
 class Helmsman:
     def __init__(self, driver):
@@ -18,11 +19,21 @@ class Helmsman:
         self._driver.set_sail(min(abs(self._driver.get_rel_wind_dir(), 90)))
 
     def turn(self, new_heading):
-        """Turns the boat to face the new_heading. Returns False if the new_heading is in the no-go zone, True otherwise"""
-        # Get distance between new get_heading and wind direction
-        if abs(self._driver.get_rel_wind_dir()) < self.tolerance:
+        """Turns the boat to face the new_heading. Returns False if the new_heading is in irons, True otherwise"""
+        # Get shortest distance between new_heading and wind direction
+        wind_dir = self._driver.get_wind_dir()
+        high = max(wind_dir, new_heading)
+        low = min(wind_dir, new_heading)
+        if high > (low + 180):
+            diff = abs((low - high) % 360)
+        else:
+            diff = high - low
+
+        # If new heading is in irons
+        if diff < self.tolerance:
             return False
-        
+
+        # Else if new heading is valid
         self.desired_heading = new_heading
         return True
 
@@ -41,8 +52,3 @@ class Helmsman:
             return "STARBOARD"
         else:
             return "PORT"
-
-
-
-
-

--- a/pi/imu/IMU.py
+++ b/pi/imu/IMU.py
@@ -3,11 +3,12 @@ import xsensdeviceapi as xda
 
 from time import perf_counter, sleep
 
+
 class IMU:
     def __init__(self):
         self._control = xda.XsControl_construct()
 
-        #finding the port the imu is connected to
+        # finding the port the imu is connected to
         for port in xda.XsScanner_scanPorts():
             if port.deviceId().isMti() or port.deviceId().isMtig():
                 self._port = port
@@ -15,29 +16,29 @@ class IMU:
         else:
             raise RuntimeError('IMU not found')
 
-        #opening port
+        # opening port
         self._control.openPort(self._port.portName(), self._port.baudrate())
 
-        #getting the device object from the id
+        # getting the device object from the id
         self._device = self._control.device(self._port.deviceId())
 
-        #setting up callback handler
+        # setting up callback handler
         self._callback = XdaCallback(max_buffer_size=1)
         self._device.addCallbackHandler(self._callback)
 
-        #configuring the device
+        # configuring the device
         self._device.gotoConfig()
         configArray = xda.XsOutputConfigurationArray()
         configArray.push_back(xda.XsOutputConfiguration(xda.XDI_PacketCounter, 0))
         configArray.push_back(xda.XsOutputConfiguration(xda.XDI_SampleTimeFine, 0))
         configArray.push_back(xda.XsOutputConfiguration(xda.XDI_Quaternion, 0))
 
-        #putting device into measurement mode
+        # putting device into measurement mode
         self._device.gotoMeasurement()
 
     def orientation(self):
         start = perf_counter()
-        #process will wait half a second at most
+        # process will wait half a second at most
         while perf_counter() - start < 0.5:
             if self._callback.packetAvailable():
                 orientation = self._callback.getNextPacket().orientationEuler()
@@ -52,6 +53,7 @@ class IMU:
         self._device.removeCallbackHandler(self._callback)
         self._control.closePort(self._port.portName())
         self._control.close()
+
 
 if __name__ == '__main__':
     imu = IMU()

--- a/pi/requirements.txt
+++ b/pi/requirements.txt
@@ -1,0 +1,2 @@
+simple-pid==0.2.3
+pyserial==3.4


### PR DESCRIPTION
Fixed turn method to get proper distance between new heading and current wind.

Added requirements and an __init__.py so you can from the base directory after importing helmsmen you can call helmsmen.Helmsmen() rather than helmsmen.helmsmen.Helmsmen() in general I think it's best to not have .py files the same name as the module.  Possibly rename the module to something more generic such as control? That way if you were doing the long import from main directory it would be import control; control.helmsmen.Helmsmen().

But I just might be being pedantic
https://docs.python-guide.org/writing/structure/